### PR TITLE
Add DKIM Message Authentication Status handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,6 +382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
+name = "beef"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +870,15 @@ name = "either"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "enum-ordinalize"
@@ -1668,6 +1683,8 @@ dependencies = [
  "fluvio",
  "fluvio-connector-common",
  "futures",
+ "mail-parser",
+ "msg-auth-status",
  "serde",
  "serde_json",
  "thiserror",
@@ -1885,6 +1902,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "logos"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161971eb88a0da7ae0c333e1063467c5b5727e7fb6b710b8db4814eade3a42e8"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e31badd9de5131fdf4921f6473d457e3dd85b11b7f091ceb50e4df7c3eeb12a"
+dependencies = [
+ "beef",
+ "fnv",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "regex-syntax 0.8.3",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2a69b3eb68d5bd595107c9ee58d7e07fe2bb5e360cc85b0f084dedac80de0a"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +1950,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mail-parser"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5a1335c3a964788c90cb42ae04a34b5f2628e89566949ce3bd4ada695c0bcd"
+dependencies = [
+ "encoding_rs",
+ "serde",
 ]
 
 [[package]]
@@ -1958,6 +2018,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "msg-auth-status"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "611910f10f653fe973c49f1840de955091cfcb28fd8aa191d0b2286f30ec7294"
+dependencies = [
+ "logos",
+ "mail-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ fluvio = { git = "https://github.com/infinyon/fluvio", rev = "06450c8" }
 fluvio-connector-common = { git = "https://github.com/infinyon/fluvio", rev = "06450c8", features = ["derive"] }
 async-imap = { version = "0.9" }
 async-native-tls = "0.5.0"
+mail-parser = { version = "0.9", features = ["serde_support"] }
+msg-auth-status = { version = "0.2", features = ["verifier"] }
 
 [profile.release-lto]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -12,10 +12,14 @@ Reads from IMAP and writes to Fluvio topic.
 | user                | -        | String         | Username for plaintext login - must be over TLS - e.g. STARTTLS over 143 or directly over 993 TLS port         |
 | password            | -        | String         | Password for plaintext login - must be over TLS                                                                |
 | mailbox             | -        | String         | Mailbox to SELECT e.g. INBOX, Junk Mail etc. - deploy connector instance per Mailbox streaming                 |
-| search              | -        | String         | e.g. NEW - see RFC for SEARCH - this is executed upon new mail                                                 |
+| search              | -        | String         | e.g. UNSEEN - see RFC for SEARCH - this is executed upon new mail                                              |
 | fetch               | -        | String         | e.g. (UID FLAGS INTERNALDATE RFC822.SIZE RFC822 RFC822.HEADER ENVELOPE BODYSTRUCTURE)                          |
 | mode_bytes          | false    | bool           | Output bytes e.g. for headers & body RFC822 case                                                               |
 | mode_utf8_lossy     | false    | bool           | Output lossy UTF8  - assume only into UTF8 Strings and scrap bytes                                             |
+| mode_parser         | false    | bool           | Output parsed E-mail                                                                                           |
+| mode_dkim_auth      | false    | bool           | Output status of Authentication-Results dkim method pass or fail                                               |
+| dkim_authenticated_move | -    | String         | If the fetched new email has "Pass" status for Authentication-Results in DKIM method, move email into this Mailbox |
+| dkim_unauthenticated_move | -  | String         | If the fetched new email has "Fail" or "None" status instead in the DKIM method, move email into this Mailbox  |
 | dangerous_cert      | false    | String         | DANGEROUS: Upon development / debugging skip TLS cert verify - true (default false)                            |
 
 Enable either mode_bytes or mode_utf8_lossy or both.
@@ -36,14 +40,23 @@ cdk deploy list # to see the status
 cdk deploy log my-imap-connector # to see connector's logs
 ```
 
-Insert records:
-```bash
+## DKIM Authentication
+
+This connector supports checking the "Authentication-Results" header (as per RFC 8601) to move the e-mail accordingly.
+
+DKIM Non-Authenticated e-mails typically show up as:
+```json
+{"uid":"29","dkim_authenticated":false,"moved_to":"Unauthenticated","internaldate":"2024-07-05T02:26:27+00:00"}
 ```
 
-The produced record in Fluvio topic will be:
+DKIM Authenticated e-mails typically show up as:
 ```json
-{}
+{"uid":"30","dkim_authenticated":true,"moved_to":"Authenticated","internaldate":"2024-07-05T02:26:27+00:00"}
 ```
+
+### Notes
+
+* DKIM Authentication relies on the e-mail infrastructure correctly handling "Message Authentication Status" via Authentication-Results header to set the dkim accordingly.
 
 ### Transformations
 Fluvio Imap Source Connector supports [Transformations](https://www.fluvio.io/docs/concepts/transformations-chain/).

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,5 +12,9 @@ pub(crate) struct ImapConfig {
     pub fetch: String,
     pub mode_bytes: bool,
     pub mode_utf8_lossy: bool,
+    pub mode_parser: bool,
+    pub mode_dkim_auth: bool,
+    pub dkim_authenticated_move: Option<String>,
+    pub dkim_unauthenticated_move: Option<String>,
     pub dangerous_cert: bool,
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -161,7 +161,7 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
         None => info!("config.dkim_unathenticated_move was not set - Will not move any DKIM Non-Authenticated emails."),
     }
 
-    if ensure_mailboxes_exist.len() > 0 {
+    if !ensure_mailboxes_exist.is_empty() {
         let mut list = fetch_session.list(Some("*"), Some("*")).await.unwrap();
 
         while let Some(item) = list.next().await {
@@ -282,22 +282,16 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
                 // Move the mail in case Authenticated destination folder is set
                 // and dkim_authenticated == true
                 if let Some(dkim_move_to) = &config.dkim_authenticated_move {
-                    match rec.dkim_authenticated {
-                        Some(true) => {
-                            rec.moved_to = Some(dkim_move_to.clone());
-                        }
-                        _ => {}
+                    if let Some(true) = rec.dkim_authenticated {
+                        rec.moved_to = Some(dkim_move_to.clone());
                     }
                 }
 
                 // Move the mail in case Unauthenticated destination folder is set
                 // and dkim_authenticated == false
                 if let Some(dkim_move_to) = &config.dkim_unauthenticated_move {
-                    match rec.dkim_authenticated {
-                        Some(false) => {
-                            rec.moved_to = Some(dkim_move_to.clone());
-                        }
-                        _ => {}
+                    if let Some(false) = rec.dkim_authenticated {
+                        rec.moved_to = Some(dkim_move_to.clone());
                     }
                 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -8,9 +8,13 @@ use async_std::task::spawn;
 use async_trait::async_trait;
 use fluvio::Offset;
 #[allow(unused_imports)]
-use fluvio_connector_common::tracing::{debug, info, trace};
+use fluvio_connector_common::tracing::{debug, info, trace, warn};
 use fluvio_connector_common::Source;
 use futures::{stream::LocalBoxStream, StreamExt};
+
+use msg_auth_status::alloc_yes::{MessageAuthStatus, ReturnPathVerifier, ReturnPathVerifierStatus};
+
+use std::collections::HashMap;
 
 const CHANNEL_BUFFER_SIZE: usize = 10000;
 
@@ -25,6 +29,10 @@ pub(crate) struct ImapSource {
     fetch: String,
     mode_bytes: bool,
     mode_utf8_lossy: bool,
+    mode_parser: bool,
+    mode_dkim_auth: bool,
+    dkim_authenticated_move: Option<String>,
+    dkim_unauthenticated_move: Option<String>,
     dangerous_cert: bool,
 }
 
@@ -39,6 +47,10 @@ impl ImapSource {
         let fetch = config.fetch.clone();
         let mode_utf8_lossy = config.mode_utf8_lossy;
         let mode_bytes = config.mode_bytes;
+        let mode_parser = config.mode_parser;
+        let mode_dkim_auth = config.mode_dkim_auth;
+        let dkim_authenticated_move = config.dkim_authenticated_move.clone();
+        let dkim_unauthenticated_move = config.dkim_unauthenticated_move.clone();
         let dangerous_cert = config.dangerous_cert;
 
         Ok(Self {
@@ -51,6 +63,10 @@ impl ImapSource {
             fetch,
             mode_utf8_lossy,
             mode_bytes,
+            mode_parser,
+            mode_dkim_auth,
+            dkim_authenticated_move,
+            dkim_unauthenticated_move,
             dangerous_cert,
         })
     }
@@ -105,21 +121,73 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
         .await
         .map_err(|(err, _client)| err)?;
 
-    /* TODO
-    let mut list = fetch_session.list(Some("*"), Some("*")).await.unwrap();
-    while let Some(item) = list.next().await {
+    // Figure out if the message passed DKIM auth for Return-Path
+    let mut do_dkim_auth = config.mode_dkim_auth;
 
-        info!("IMAP List item = {:?}", item.unwrap());
+    #[derive(Debug, Default)]
+    struct MboxCheck {
+        exists: bool,
     }
-    drop(list);
-     */
+
+    let mut ensure_mailboxes_exist: HashMap<String, MboxCheck> = HashMap::new();
+
+    // If DKIM Authenticated messages are to be moved - make sure the associated Mailbox exists
+    // The mailbox must be set in dkim_authenticated_move within the Configuration
+    // Consequently if do_dkim_auth was not set this will be set true if to be moved
+    match &config.dkim_authenticated_move {
+        Some(auth_outbox) => {
+            if !do_dkim_auth {
+                warn!("mode_dkim_auth was set to false - Turning to true due to dkim_authenticated_move set.");
+                do_dkim_auth = true;
+            }
+            info!("Will move DKIM Authenticated emails to mailbox {} - Checking the existence.", &auth_outbox);
+            ensure_mailboxes_exist.insert(auth_outbox.clone(), MboxCheck::default() );
+        }
+        None => info!("config.dkim_athenticated_move was not set - Will not move any DKIM Authenticated emails."),
+    }
+
+    // If DKIM Non-Authenticated messages are to be moved - make sure the associated Mailbox exists
+    // The mailbox must be set in dkim_unauthenticated_move within the Configuration
+    // Consequently if do_dkim_auth was not set this will be set true if to be moved
+    match &config.dkim_unauthenticated_move {
+        Some(unauth_outbox) => {
+            if !do_dkim_auth {
+                warn!("mode_dkim_auth was set to false - Turning to true due to dkim_unauthenticated_move set.");
+                do_dkim_auth = true;
+            }
+            info!("Will move DKIM Non-Authenticated emails to mailbox {} - Checking the existence.", &unauth_outbox);
+            ensure_mailboxes_exist.insert(unauth_outbox.clone(), MboxCheck::default() );
+        }
+        None => info!("config.dkim_unathenticated_move was not set - Will not move any DKIM Non-Authenticated emails."),
+    }
+
+    if ensure_mailboxes_exist.len() > 0 {
+        let mut list = fetch_session.list(Some("*"), Some("*")).await.unwrap();
+
+        while let Some(item) = list.next().await {
+            let saw = item.expect("Failed to fetch Mailbox list");
+            let saw_name = saw.name();
+            if let Some(ref mut mbox) = &mut ensure_mailboxes_exist.get_mut(saw_name) {
+                mbox.exists = true;
+            }
+        }
+        drop(list);
+
+        for (create_mailbox, check_status) in ensure_mailboxes_exist.iter() {
+            if !check_status.exists {
+                info!("Creating needed mailbox {}", &create_mailbox);
+                fetch_session.create(&create_mailbox).await?;
+            } else {
+                info!("Mailbox already exists {}", &create_mailbox);
+            }
+        }
+    }
 
     let idle_inbox = idle_session.select(&config.mailbox).await?;
     let _fetch_inbox = fetch_session.select(&config.mailbox).await?;
 
-    info!("IMAP Connecting Mailbox {}", &config.mailbox);
-
-    info!("IMAP idle_inbox = {:?}", idle_inbox);
+    info!("IMAP Connecting to Mailbox {}", &config.mailbox);
+    info!("IMAP idle_inbox cur = {:?}", idle_inbox);
 
     let mut idle_handle = idle_session.idle();
 
@@ -132,6 +200,8 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
         }
         drop(search);
 
+        let mut uid_moves: Vec<(String, String)> = vec![];
+
         for fetch_uid in &to_fetch {
             info!("Fetching UID {:?}", fetch_uid);
             let mut fetch_new = fetch_session
@@ -139,10 +209,15 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
                 .await?;
             while let Some(item_u) = fetch_new.next().await {
                 let mut rec = ImapEvent {
-                    uid: *fetch_uid,
+                    uid: fetch_uid.to_string(),
+                    dkim_authenticated: None,
+                    dkim_authenticated_error: None,
+                    moved_to: None,
                     flags: None,
                     body: None,
                     body_utf8_lossy: None,
+                    header_parsed: None,
+                    body_parsed: None,
                     header: None,
                     header_utf8_lossy: None,
                     text: None,
@@ -154,6 +229,27 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
                 let item = &item_u.unwrap();
 
                 if let Some(header) = item.header() {
+                    if config.mode_parser {
+                        let parsed = mail_parser::MessageParser::default().parse(header).unwrap();
+                        rec.header_parsed = Some(parsed);
+                    }
+                    if do_dkim_auth {
+                        let parsed = mail_parser::MessageParser::default().parse(header).unwrap();
+                        let auth_status = MessageAuthStatus::from_mail_parser(&parsed).unwrap();
+                        let verifier =
+                            ReturnPathVerifier::from_alloc_yes(&auth_status, &parsed).unwrap();
+                        match verifier.verify() {
+                            Ok(ReturnPathVerifierStatus::Pass) => {
+                                rec.dkim_authenticated = Some(true);
+                            }
+                            Ok(_) => {
+                                rec.dkim_authenticated = Some(false);
+                            }
+                            Err(e) => {
+                                rec.dkim_authenticated_error = Some(format!("{:?}", e));
+                            }
+                        }
+                    }
                     if config.mode_bytes {
                         rec.header = Some(header.into());
                     }
@@ -167,6 +263,10 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
                     rec.envelope = Some(imap_envelope);
                 }
                 if let Some(body) = &item.body() {
+                    if config.mode_parser {
+                        let parsed = mail_parser::MessageParser::default().parse(*body).unwrap();
+                        rec.body_parsed = Some(parsed);
+                    }
                     if config.mode_bytes {
                         rec.body = Some(body.to_vec());
                     }
@@ -179,8 +279,39 @@ async fn imap_loop(tx: Sender<String>, config: ImapSource) -> Result<()> {
                     rec.internaldate = Some(internal_date.to_rfc3339());
                 }
 
+                // Move the mail in case Authenticated destination folder is set
+                // and dkim_authenticated == true
+                if let Some(dkim_move_to) = &config.dkim_authenticated_move {
+                    match rec.dkim_authenticated {
+                        Some(true) => {
+                            rec.moved_to = Some(dkim_move_to.clone());
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Move the mail in case Unauthenticated destination folder is set
+                // and dkim_authenticated == false
+                if let Some(dkim_move_to) = &config.dkim_unauthenticated_move {
+                    match rec.dkim_authenticated {
+                        Some(false) => {
+                            rec.moved_to = Some(dkim_move_to.clone());
+                        }
+                        _ => {}
+                    }
+                }
+
+                // Move the mail between Mailboxes
+                if let Some(ref move_to) = rec.moved_to {
+                    uid_moves.push((rec.uid.clone(), move_to.clone()));
+                }
+
                 tx.send(rec.try_into()?).await?;
             }
+        }
+
+        for (move_uid, move_to) in uid_moves.iter() {
+            fetch_session.uid_mv(move_uid, move_to).await?;
         }
 
         info!("IMAP Idling & Waiting for 5 minutes");


### PR DESCRIPTION
Closes #4 

- Adds network-less DKIM Message Authentication status handling
- Authentication itself is done within the existing modern e-mail infrastructure according to RFC 6376 & 8601
- The source connector allows moving based DKIM = pass / fails e-mails into separate Mailbox relevant to the status
- Uses [msg-auth-status](https://github.com/areweat/msg-auth-status) crate for parsing & verifying Authentication-Results header for dkim = ...
